### PR TITLE
now works with QTKitPLayer

### DIFF
--- a/src/GLView.h
+++ b/src/GLView.h
@@ -34,11 +34,13 @@
 	BOOL isAnimating;
     
     bool bEnableSetupScreen;
+    
 }
 
 @property(nonatomic, assign) id delegate;
 @property (assign)   bool bEnableSetupScreen;
 
+- (void) timerFired:(id)sender;
 - (id) initWithFrame:(NSRect)frameRect;
 - (id) initWithFrame:(NSRect)frameRect shareContext:(NSOpenGLContext*)context;
 

--- a/src/ofxCocoaWindow.h
+++ b/src/ofxCocoaWindow.h
@@ -55,6 +55,8 @@ public:
 
 	void		enableSetupScreen();
 	void		disableSetupScreen();
+    
+    void        test();
 	
 protected:
 	ofOrientation       orientation;

--- a/src/ofxCocoaWindow.mm
+++ b/src/ofxCocoaWindow.mm
@@ -142,8 +142,8 @@ ofOrientation ofxCocoaWindow :: getOrientation()
 //------------------------------------------------------------
 void ofxCocoaWindow :: setWindowPosition( int x, int y ) 
 {
-    if( [ [ NSApp delegate ] windowMode ] == OF_FULLSCREEN )
-        return; // only do this in OF_WINDOW mode.
+//    if( [ [ NSApp delegate ] windowMode ] == OF_FULLSCREEN )
+//        return; // only do this in OF_WINDOW mode.
     
 	NSRect viewFrame  = [ [ NSApp delegate ] getViewFrame ];
 	NSRect screenRect = [ [ NSApp delegate ] getScreenFrame ];
@@ -155,8 +155,8 @@ void ofxCocoaWindow :: setWindowPosition( int x, int y )
 //------------------------------------------------------------
 void ofxCocoaWindow :: setWindowShape( int w, int h )
 {
-    if( [ [ NSApp delegate ] windowMode ] == OF_FULLSCREEN )
-        return; // only do this in OF_WINDOW mode.
+//    if( [ [ NSApp delegate ] windowMode ] == OF_FULLSCREEN )
+//        return; // only do this in OF_WINDOW mode.
     
     NSRect windowFrame  = [ [ NSApp delegate ] getWindowFrame ];
 	NSRect viewFrame    = [ [ NSApp delegate ] getViewFrame ];
@@ -183,6 +183,13 @@ void ofxCocoaWindow :: hideCursor()
 void ofxCocoaWindow :: showCursor() 
 {
 	[ NSCursor unhide ];
+    cout <<  [[ NSApp delegate ] getFrameRate] << endl;
+}
+
+//------------------------------------------------------------
+void ofxCocoaWindow :: test()
+{
+	cout <<  "bla"<< endl;
 }
 
 //------------------------------------------------------------
@@ -206,6 +213,7 @@ void ofxCocoaWindow :: toggleFullscreen()
 	if( [ [ NSApp delegate ] windowMode ] == OF_WINDOW )
     {
 		[ [ NSApp delegate ] goFullScreenOnAllDisplays ];
+       // [ [ NSApp delegate ] goFullScreen:NSMakeRect(1, 900-300, 400, 300) ];
     }
     else if( [ [ NSApp delegate ] windowMode ] == OF_FULLSCREEN )
     {


### PR DESCRIPTION
CVDisplayLink now triggers [self setNeedsDisplay:YES]; via [self performSelectorOnMainThread:@selector(timerFired:) withObject:nil waitUntilDone:NO ]; plus dont use CGLLockContext, now QTKit plays nice, overall animation is less fluid, also a pixelsetting for antialiasing...

... needs a bit cleanup ...next year :)
